### PR TITLE
Add a TERMINATE command to the debugger and corresponding debugger files

### DIFF
--- a/t86/debugger/Native.h
+++ b/t86/debugger/Native.h
@@ -224,6 +224,10 @@ public:
             ContinueExecution();
         }
     }
+
+    void Terminate() {
+        process->Terminate();
+    }
 protected:
     /// Returns SW BP opcode for current architecture.
     std::string_view GetSoftwareBreakpointOpcode() {

--- a/t86/debugger/Process.h
+++ b/t86/debugger/Process.h
@@ -30,6 +30,9 @@ public:
     virtual void ResumeExecution() = 0;
     virtual size_t TextSize() = 0;
     virtual void Wait() = 0;
+    /// Cause the process to end, the class should not be used
+    /// after this function is called.
+    virtual void Terminate() = 0;
 protected:
 };
 

--- a/t86/debugger/T86Process.h
+++ b/t86/debugger/T86Process.h
@@ -153,6 +153,11 @@ public:
             throw DebuggerError(fmt::format("Expected STOPPED message in Wait()"));
         }
     }
+
+    void Terminate() override {
+        process->Send("TERMINATE");
+        CheckResponse("TERMINATE fail");
+    }
 private:
     int64_t GetRegister(std::string_view name) {
         process->Send(fmt::format("PEEKREGS {}", name));

--- a/t86/t86/debug.h
+++ b/t86/t86/debug.h
@@ -167,6 +167,9 @@ public:
             } else if (command == "DATASIZE") {
                 messenger->Send(fmt::format("DATASIZE:{}",
                                             Cpu::Config::instance().ramSize()));
+            } else if (command == "TERMINATE") {
+                messenger->Send("OK");
+                return false;
             } else {
                 messenger->Send("UNKNOWN COMMAND");
                 continue;

--- a/t86/t86/os.cpp
+++ b/t86/t86/os.cpp
@@ -16,8 +16,8 @@ void OS::DispatchInterrupt(int n) {
         DebuggerMessage(Debug::BreakReason::SingleStep);
         break;
     default:
-        // TODO: Add logging!
-        throw std::runtime_error(fmt::format("No interrupt handler for interrupt no. {}!", n));
+        throw std::runtime_error(
+              fmt::format("No interrupt handler for interrupt no. {}!", n));
         break;
     }
 }
@@ -38,6 +38,20 @@ void OS::Run(Program program) {
             log_info("Interrupt {} occurred", n);
             DispatchInterrupt(n);
         }
+
+        if (stop) {
+            log_info("OS: stop is set, ending");
+            return;
+        }
+    }
+}
+
+void OS::DebuggerMessage(Debug::BreakReason reason) {
+    if (debug_interface) {
+        stop = !debug_interface->Work(reason);
+    } else {
+        log_warning("Call to debugger interface was initiated but no "
+                    "debugger is connected!");
     }
 }
 }

--- a/t86/t86/os.h
+++ b/t86/t86/os.h
@@ -19,16 +19,14 @@ public:
         debug_interface.emplace(cpu, std::move(m));
     }
 private:
+    void DebuggerMessage(Debug::BreakReason reason);
     void DispatchInterrupt(int n);
     /// If debug interface is present then sends message to it,
     /// otherwise noop.
-    void DebuggerMessage(Debug::BreakReason reason) {
-        if (debug_interface) {
-            debug_interface->Work(reason);
-        }
-    }
-
+    /// If returns false then the execution should be aborted.
     Cpu cpu;
     std::optional<Debug> debug_interface;
+    /// Indicates whether the execution should stop.
+    bool stop{false};
 };
 }

--- a/t86/tests/debugger/t86process_test.cpp
+++ b/t86/tests/debugger/t86process_test.cpp
@@ -507,3 +507,29 @@ TEST(T86ProcessCpuTest, Memory) {
     t86.ResumeExecution();
     t_os.join();
 }
+
+TEST(T86ProcessCpuTest, Terminate) {
+    const size_t REG_COUNT = 3;
+    ThreadQueue<std::string> q1;
+    ThreadQueue<std::string> q2;
+    auto tm1 = std::make_unique<ThreadMessenger>(q1, q2);
+    auto tm2 = std::make_unique<ThreadMessenger>(q2, q1);
+    auto program = R"(
+.text
+
+0 MOV R0, [1]
+1 NOP
+2 ADD R0, [2]
+3 MOV R2, [2]
+4 HALT
+)";
+    std::thread t_os(RunCPU, std::move(tm1), program, REG_COUNT);
+    
+    auto t86 = T86Process(std::move(tm2), REG_COUNT);
+    t86.Wait();
+    t86.Singlestep();
+    t86.Wait();
+    t86.Terminate();
+    // Should not hang
+    t_os.join();
+}


### PR DESCRIPTION
The debug API was enriched by `TERMINATE` command, which causes the T86 VM to end execution.
This is now used in CLI, which can end gracefully and not via CTRL+C.

Tests were also added for it.

Closes #34 .