### PR TITLE
Make the repo compilable on MacOS with Apple Clang

### DIFF
--- a/t86/common/helpers.h
+++ b/t86/common/helpers.h
@@ -78,12 +78,25 @@ namespace utils {
     /// from_chars wrapper that converts 's' to T.
     template<typename T>
     inline std::optional<T> svtonum(std::string_view s) {
-        T result;
-        auto [ptr, ec] { std::from_chars(s.data(), s.data() + s.size(), result) };
-        if (ec == std::errc()) {
-            return result;
+#ifdef __clang__
+        if constexpr (std::is_floating_point_v<T>) {
+            try {
+                auto res = std::stod(std::string{s});
+                return res;
+            } catch (...) {
+                return std::nullopt;
+            }
+        } else {
+#endif
+            T result;
+            auto [ptr, ec] { std::from_chars(s.data(), s.data() + s.size(), result) };
+            if (ec == std::errc()) {
+                return result;
+            }
+            return std::nullopt;
+#ifdef __clang__
         }
-        return std::nullopt;
+#endif
     }
 
     inline bool is_prefix_of(std::string_view prefix, std::string_view of) {

--- a/t86/dbg-cli/CLI.h
+++ b/t86/dbg-cli/CLI.h
@@ -148,8 +148,8 @@ public:
         if (address >= text_size) {
             return;
         }
-        size_t begin = static_cast<unsigned>(range) > address ? 0 : address - range;
-        size_t end = std::min(text_size, address + range + 1);
+        size_t begin = static_cast<size_t>(range) > address ? 0 : address - range;
+        size_t end = std::min(text_size, static_cast<size_t>(address) + range + 1);
         auto inst = process.ReadText(begin, end - begin);
         for (size_t i = 0; i < inst.size(); ++i) {
             uint64_t curr_addr = i + begin;

--- a/t86/dbg-cli/main.cpp
+++ b/t86/dbg-cli/main.cpp
@@ -1,5 +1,6 @@
 #include <argparse/argparse.hpp>
 #include <fstream>
+#include <thread>
 #include <fmt/core.h>
 
 #include "CLI.h"

--- a/t86/debugger/Native.cpp
+++ b/t86/debugger/Native.cpp
@@ -1,0 +1,1 @@
+#include "Native.h"

--- a/t86/tests/debugger/native_test.cpp
+++ b/t86/tests/debugger/native_test.cpp
@@ -1,4 +1,6 @@
 #include <gtest/gtest.h>
+#include <thread>
+#include <string>
 #include "debugger/Native.h"
 #include "common/threads_messenger.h"
 #include "t86/cpu.h"

--- a/t86/tests/debugger/t86process_test.cpp
+++ b/t86/tests/debugger/t86process_test.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <thread>
 #include "debugger/T86Process.h"
 #include "t86-parser/parser.h"
 #include "t86/os.h"

--- a/t86/tests/t86/debug_test.cpp
+++ b/t86/tests/t86/debug_test.cpp
@@ -7,6 +7,7 @@
 
 #include <string>
 #include <queue>
+#include <thread>
 
 using namespace tiny::t86;
 

--- a/t86/tests/utils_test.cpp
+++ b/t86/tests/utils_test.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <thread>
 #include "common/helpers.h"
 #include "common/threads_messenger.h"
 


### PR DESCRIPTION
Some small changes to make the repo compilable on MacOS with the XCode Apple Clang.
Unfortunately, it doesn't support `from_chars` for floating points, so an ugly workaround
was made.