### PR TITLE
Add type information about source variables.

### DIFF
--- a/t86/dbg-cli/tests/sources/swap.t86
+++ b/t86/dbg-cli/tests/sources/swap.t86
@@ -34,6 +34,15 @@
 
 .debug_info
 DIE_compilation_unit: {
+DIE_primitive_type: {
+    ATTR_name: signed_int,
+    ATTR_id: 0,
+    ATTR_size: 1,
+},
+DIE_pointer_type: {
+    ATTR_type: 1,
+    ATTR_id: 1,
+},
 DIE_function: {
     ATTR_name: main,
     ATTR_begin_addr: 7,
@@ -43,12 +52,12 @@ DIE_function: {
         ATTR_end_addr: 18,
         DIE_variable: {
             ATTR_name: a,
-            ATTR_type: int,
+            ATTR_type: 0,
             ATTR_location: [PUSH SP; PUSH -1; ADD],
         },
         DIE_variable: {
             ATTR_name: b,
-            ATTR_type: int,
+            ATTR_type: 0,
             ATTR_location: [PUSH SP; PUSH -2; ADD],
         }
     }
@@ -62,15 +71,15 @@ DIE_function: {
         ATTR_end_addr: 7,
         DIE_variable: {
             ATTR_name: x,
-           # ATTR_type, int_pointer,
+            ATTR_type: 1,
         },
         DIE_variable: {
             ATTR_name: y,
-           # ATTR_type, int_pointer,
+            ATTR_type: 1,
         },
         DIE_variable: {
             ATTR_name: tmp,
-            ATTR_type: int,
+            ATTR_type: 0,
             ATTR_location: `PUSH R0`,
         }
     }

--- a/t86/debugger/Source/Die.h
+++ b/t86/debugger/Source/Die.h
@@ -17,7 +17,7 @@ struct ATTR_end_addr {
 };
 
 struct ATTR_type {
-    std::string name;
+    size_t type_id;
 };
 
 struct ATTR_location_expr {
@@ -28,9 +28,13 @@ struct ATTR_size {
     uint64_t size;
 };
 
+struct ATTR_id {
+    size_t id;
+};
+
 struct ATTR_members {
     /// address offset from struct beginning -> name of type
-    std::map<uint64_t, std::string> m;
+    std::map<int64_t, size_t> m;
 };
 
 using DIE_ATTR = std::variant<ATTR_name,
@@ -39,7 +43,8 @@ using DIE_ATTR = std::variant<ATTR_name,
                               ATTR_type,
                               ATTR_location_expr,
                               ATTR_size,
-                              ATTR_members>;
+                              ATTR_members,
+                              ATTR_id>;
 
 /// Represents one DIE_TAG value. That value contains attributes
 /// and possibly other values.
@@ -51,6 +56,7 @@ public:
         variable,
         primitive_type,
         structured_type,
+        pointer_type,
         name,
         invalid,
         compilation_unit,

--- a/t86/debugger/Source/Parser.h
+++ b/t86/debugger/Source/Parser.h
@@ -29,7 +29,7 @@ private:
     std::map<size_t, uint64_t> DebugLine();
     DIE DebugInfo();
     DIE ParseDIE(std::string name);
-    std::map<uint64_t, std::string> StructuredMembers();
+    std::map<int64_t, size_t> StructuredMembers();
     DIE::TAG ParseDIETag(std::string_view v) const;
     DIE_ATTR ParseATTR(std::string_view v);
     std::vector<expr::LocExpr> ParseExprLoc();

--- a/t86/debugger/Source/Source.h
+++ b/t86/debugger/Source/Source.h
@@ -9,12 +9,6 @@
 /// Responsible for all source level debugging.
 class Source {
 public:
-    enum class PrimitiveTypes {
-        FLOAT,
-        INT,
-        BOOL,
-    };
-
     void RegisterSourceFile(SourceFile file) {
         source_file = std::move(file);
     }
@@ -41,8 +35,8 @@ public:
     std::optional<std::string> GetFunctionNameByAddress(uint64_t address) const;
     /// Returns the address of the function prologue.
     std::optional<uint64_t> GetAddrFunctionByName(std::string_view name);
-    /// Returns value of a variable if it is in current scope.
-    std::optional<Type> GetVariableTypeInformation(std::string_view name);
+    /// Returns the type of a variable if it is in current scope.
+    std::optional<Type> GetVariableTypeInformation(Native& native, std::string_view name);
     /// Returns a location of variable.
     /// Be aware that this can make a lot of calls to the underlying debugged
     /// process, depending on how complicated is the location expression.
@@ -63,6 +57,8 @@ public:
 
     std::optional<std::string_view> GetLine(size_t line);
 private:
+    std::optional<Type> ReconstructTypeInformation(size_t id) const;
+
     template<typename T>
     static const T& UnwrapOptional(const std::optional<T>& opt, const std::string& message) {
         if (!opt) {

--- a/t86/debugger/Source/Type.h
+++ b/t86/debugger/Source/Type.h
@@ -2,22 +2,63 @@
 #include <string>
 #include <vector>
 #include <variant>
+#include <memory>
+#include <optional>
 
-/// Represents 
-struct TypeInfo {
+struct PrimitiveType;
+struct StructuredType;
+struct PointerType;
+
+using Type = std::variant<PrimitiveType, StructuredType, PointerType>;
+
+struct PrimitiveType {
+    enum struct Type {
+        FLOAT,
+        SIGNED,
+        UNSIGNED,
+        BOOL,
+    };
+    Type type;
+    uint64_t size;
+};
+
+inline std::optional<PrimitiveType::Type> ToPrimitiveType(std::string_view type) {
+    if (type == "float") {
+        return PrimitiveType::Type::FLOAT; 
+    } else if (type == "signed_int") {
+        return PrimitiveType::Type::SIGNED;
+    } else if (type == "unsigned_int") {
+        return PrimitiveType::Type::UNSIGNED;
+    } else if (type == "bool") {
+        return PrimitiveType::Type::BOOL;
+    }
+    return {};
+}
+
+inline std::string FromPrimitiveType(PrimitiveType::Type type) {
+    switch (type) {
+    case PrimitiveType::Type::FLOAT:
+        return "float";
+    case PrimitiveType::Type::SIGNED:
+        return "int";
+    case PrimitiveType::Type::UNSIGNED:
+        return "unsigned";
+    case PrimitiveType::Type::BOOL:
+        return "bool";
+    }
+}
+
+
+struct PointerType {
+    // ptr is needed here since the types are recursive.
+    // Can be null if there is no info about the pointed type.
+    std::shared_ptr<Type> to;
+    uint64_t size;
+};
+
+struct StructuredType {
     std::string name;
-    int size;
-};
-
-class PrimitiveType;
-class StructuredType;
-
-using Type = std::variant<PrimitiveType, StructuredType>;
-
-class PrimitiveType: public TypeInfo {
-};
-
-class StructuredType: public TypeInfo {
+    uint64_t size;
     /// Offset from base of structured type - The type at that offset
-    std::vector<std::pair<int64_t, Type>> members;
+    std::vector<std::pair<int64_t, std::optional<Type>>> members;
 };

--- a/t86/debugger/Tests/swap.t86
+++ b/t86/debugger/Tests/swap.t86
@@ -34,6 +34,16 @@
 
 .debug_info
 DIE_compilation_unit: {
+DIE_primitive_type: {
+    ATTR_id: 0
+    ATTR_name: signed_int,
+    ATTR_size: 1,
+},
+DIE_pointer_type: {
+    ATTR_id: 1
+    ATTR_pointing: 0,
+    ATTR_size: 1,
+},
 DIE_function: {
     ATTR_name: main,
     ATTR_begin_addr: 7,
@@ -43,12 +53,12 @@ DIE_function: {
         ATTR_end_addr: 18,
         DIE_variable: {
             ATTR_name: a,
-            ATTR_type: int,
+            ATTR_type: 0,
             ATTR_location: [PUSH SP; PUSH -1; ADD],
         },
         DIE_variable: {
             ATTR_name: b,
-            ATTR_type: int,
+            ATTR_type: 0,
             ATTR_location: [PUSH SP; PUSH -2; ADD],
         }
     }
@@ -62,11 +72,11 @@ DIE_function: {
         ATTR_end_addr: 7,
         DIE_variable: {
             ATTR_name: x,
-           # ATTR_type, int_pointer,
+            ATTR_type, 1,
         },
         DIE_variable: {
             ATTR_name: y,
-           # ATTR_type, int_pointer,
+            ATTR_type, 1,
         },
         DIE_variable: {
             ATTR_name: tmp,


### PR DESCRIPTION
Source class is now able to fetch type information about source variables. The information allows for only partial information to be specified. Ie. for pointers you don't necessarily have to specify which type it points to. But of course the information will not be as verbose then. This unfortunately creates a lot of "Go like" optionals with ifs.

The DIE types were reworked to link to each other not via names but rather via ids. The ids should be unique for each DIE if specified, kind of like HTML div ids.

The information is constructed every time the information is needed. Although this can be slow, the T86 programs are so short it is of no matter. Also, there won't be that many types at any time in the program.