### PR TITLE
Fix T86 parser not parsing debug_source properly.

### DIFF
--- a/t86/t86-parser/parser.cpp
+++ b/t86/t86-parser/parser.cpp
@@ -511,6 +511,10 @@ tiny::t86::Program Parser::Parse() {
     }
     while (curtok.kind == TokenKind::DOT) {
         GetNext();
+        if (curtok.kind == TokenKind::ID
+                && lex.getId() == "debug_source") {
+            return {std::move(program), std::move(data)};
+        }
         Section();
     }
     CheckEnd();

--- a/t86/tests/debugger/utils.h
+++ b/t86/tests/debugger/utils.h
@@ -99,7 +99,7 @@ inline void RunCPU(std::unique_ptr<ThreadMessenger> messenger,
 
 class NativeSourceTest: public ::testing::Test {
 protected:
-    void Run(const char* elf, const char* source_code) {
+    void Run(const char* elf) {
         const size_t REG_COUNT = 6;
         auto tm1 = std::make_unique<ThreadMessenger>(q1, q2);
         auto tm2 = std::make_unique<ThreadMessenger>(q2, q1);
@@ -112,9 +112,7 @@ protected:
         auto debug_info = p.Parse();
         source.RegisterLineMapping(std::move(*debug_info.line_mapping));
         source.RegisterDebuggingInformation(std::move(*debug_info.top_die));
-
-        SourceFile file(source_code);
-        source.RegisterSourceFile(std::move(file));
+        source.RegisterSourceFile(std::move(*debug_info.source_code));
     }
 
     void TearDown() override {


### PR DESCRIPTION
The T86 parser did not parse debug_source properly if it contained dot (because that is the start of next section). Thanks to this change we could insert the source codes into one file in tests.
Fixes #78 