### PR TITLE
Add hardware memory breakpoint support to T86.

### DIFF
--- a/t86/t86/cpu.h
+++ b/t86/t86/cpu.h
@@ -217,6 +217,16 @@ namespace tiny::t86 {
         void unsetTrapFlag();
 
         bool isTrapFlagSet();
+
+        static const size_t DEBUG_REGISTERS_CNT = 5;
+
+        uint64_t getDebugRegister(size_t i) const {
+            return debug_registers_.at(i);
+        }
+
+        void setDebugRegister(size_t i, uint64_t value) {
+            debug_registers_.at(i) = value;
+        }
     private:
         /// If true then after every retired instruction an interrupt 1 is sent.
         /// TODO: This should really be a part of flags register. For now however,
@@ -234,6 +244,10 @@ namespace tiny::t86 {
         void registerBranchTaken(uint64_t sourcePc, uint64_t destination);
 
         PhysicalRegister nextFreeRegister() const;
+
+        /// Checks if any of the writes were done to location watched by debug
+        /// registers and if so then sets an interrupt.
+        void checkWrite(uint64_t address);
 
         // Harvard architecture
         Program program_;
@@ -269,6 +283,12 @@ namespace tiny::t86 {
 
         // Values of registers, indexed by PhysicalRegister
         std::vector<RegisterValue> registers_;
+
+        // Debug registers
+        // first four bits indicate whether i-th debug reg is active.
+        // 8-12 bits indicate which debug reg caused break.
+        static const size_t DEBUG_CONTROL_REG_IDX = DEBUG_REGISTERS_CNT - 1;
+        std::array<uint64_t, DEBUG_REGISTERS_CNT> debug_registers_;
 
         // Register allocation table
         RegisterAllocationTable rat_;

--- a/t86/t86/cpu/memory_writes_manager.h
+++ b/t86/t86/cpu/memory_writes_manager.h
@@ -15,7 +15,8 @@ namespace tiny::t86 {
             return currentId;
         }
 
-        /// Removes all finished outgoing writes
+        /// Removes all finished outgoing writes and returns
+        /// addresses of the finished writes.
         void removeFinished(const RAM& ram);
 
         /**

--- a/t86/t86/cpu/reservation_station.cpp
+++ b/t86/t86/cpu/reservation_station.cpp
@@ -307,6 +307,8 @@ namespace tiny::t86 {
         if (cpu_.isTrapFlagSet()) {
             unrollSpeculation();
             cpu_.singleStepped();
+        } else if (cpu_.interrupted()) {
+            unrollSpeculation();
         }
         log_info("Retired instruction '{}'", instruction_->toString());
     }

--- a/t86/t86/os.cpp
+++ b/t86/t86/os.cpp
@@ -12,6 +12,9 @@ void OS::DispatchInterrupt(int n) {
     case 3:
         DebuggerMessage(Debug::BreakReason::SoftwareBreakpoint);
         break;
+    case 2:
+        DebuggerMessage(Debug::BreakReason::HardwareBreakpoint);
+        break;
     case 1:
         DebuggerMessage(Debug::BreakReason::SingleStep);
         break;

--- a/t86/tests/debugger/source_test.cpp
+++ b/t86/tests/debugger/source_test.cpp
@@ -410,8 +410,6 @@ DIE_function: {
 }
 
 TEST_F(NativeSourceTest, FunctionMapping1) {
-    auto source_code =
-R"()";
     const char* elf =
 R"(
 .text
@@ -756,8 +754,6 @@ int main() {
 }
 
 TEST_F(NativeSourceTest, TestMappingScopes) {
-    auto source_code =
-R"()";
     auto elf =
 R"(.text
 0   CALL 2


### PR DESCRIPTION
The T86 now has special 5 debug registers. The first four are for setting a memory address. The fifth is a special control register which is for enabling/disabling hardware breakpoints or to accumulate various information, like which register caused the breakpoint.

The breakpoint check is at the end of a write, if the write agrees with some register then interrupt flag is set. Additionaly, instruction retirement has to check if interrupt occured and unroll speculation if it did.