### PR TITLE
Add variable command to CLI.

### DIFF
--- a/t86/dbg-cli/tests/sources/swap.t86
+++ b/t86/dbg-cli/tests/sources/swap.t86
@@ -55,12 +55,12 @@ DIE_function: {
         DIE_variable: {
             ATTR_name: a,
             ATTR_type: 0,
-            ATTR_location: [PUSH SP; PUSH -1; ADD],
+            ATTR_location: [PUSH SP; PUSH -2; ADD],
         },
         DIE_variable: {
             ATTR_name: b,
             ATTR_type: 0,
-            ATTR_location: [PUSH SP; PUSH -2; ADD],
+            ATTR_location: [PUSH SP; PUSH -3; ADD],
         }
     }
 },
@@ -74,10 +74,12 @@ DIE_function: {
         DIE_variable: {
             ATTR_name: x,
             ATTR_type: 1,
+            ATTR_location: ``,
         },
         DIE_variable: {
             ATTR_name: y,
             ATTR_type: 1,
+            ATTR_location: ``,
         },
         DIE_variable: {
             ATTR_name: tmp,

--- a/t86/dbg-cli/tests/variables.conf
+++ b/t86/dbg-cli/tests/variables.conf
@@ -1,0 +1,1 @@
+sources/swap.t86

--- a/t86/dbg-cli/tests/variables.in
+++ b/t86/dbg-cli/tests/variables.in
@@ -1,0 +1,12 @@
+r
+var get a
+b s 2
+b s 10
+c
+var get x
+var get tmp
+c
+var get a
+var set a -55
+var get a
+c

--- a/t86/dbg-cli/tests/variables.ref
+++ b/t86/dbg-cli/tests/variables.ref
@@ -1,0 +1,23 @@
+Started process 'tests/sources/swap.t86'
+Error: Variable 'a' is not in scope or missing debug info
+Breakpoint set on line 2 (addr 3):     *x = *y;
+Breakpoint set on line 10 (addr 12):     print(a);
+Process stopped, reason: Software breakpoint hit at line 2
+      0:void swap(int* x, int* y) {
+      1:    int tmp = *x;
+->    2:    *x = *y;
+      3:    *y = tmp;
+      4:}
+Error: Variable 'x' is not in scope or missing debug info
+(R0; int) tmp = 3
+Process stopped, reason: Software breakpoint hit at line 10
+      8:    int b = 6;
+      9:    swap(&a, &b);
+->   10:    print(a);
+     11:    print(b);
+     12:}
+([1021]; int) a = 6
+([1021]; int) a = -55
+-55
+3
+Process stopped, reason: The program finished execution

--- a/t86/debugger/Source/ExpressionInterpreter.cpp
+++ b/t86/debugger/Source/ExpressionInterpreter.cpp
@@ -43,7 +43,7 @@ expr::Location ExpressionInterpreter::AddOperands(const expr::Location& o1,
                     return expr::Offset{rval1 + rval2};
                 },
             }, o2);
-        }
+        },
     }, o1);
 }
 

--- a/t86/debugger/Source/LocExpr.h
+++ b/t86/debugger/Source/LocExpr.h
@@ -1,4 +1,6 @@
 #pragma once
+#include "fmt/core.h"
+#include "helpers.h"
 #include <string>
 #include <variant>
 /// Describes the location in the executing code.
@@ -16,6 +18,17 @@ struct Offset {
 };
 
 using Location = std::variant<Register, Offset>;
+
+inline std::string LocationToStr(const Location& loc) {
+    return std::visit(utils::overloaded {
+        [](const Register& reg) {
+            return reg.name;
+        },
+        [](const Offset& offset) {
+            return fmt::format("[{}]", offset.value);
+        }
+    }, loc);
+}
 
 struct Push {
     Location value;

--- a/t86/debugger/Source/Type.h
+++ b/t86/debugger/Source/Type.h
@@ -1,4 +1,6 @@
 #pragma once
+#include "fmt/core.h"
+#include "helpers.h"
 #include <string>
 #include <vector>
 #include <variant>
@@ -12,7 +14,7 @@ struct PointerType;
 using Type = std::variant<PrimitiveType, StructuredType, PointerType>;
 
 struct PrimitiveType {
-    enum struct Type {
+    enum class Type {
         FLOAT,
         SIGNED,
         UNSIGNED,
@@ -46,6 +48,7 @@ inline std::string FromPrimitiveType(PrimitiveType::Type type) {
     case PrimitiveType::Type::BOOL:
         return "bool";
     }
+    UNREACHABLE;
 }
 
 
@@ -62,3 +65,16 @@ struct StructuredType {
     /// Offset from base of structured type - The type at that offset
     std::vector<std::pair<int64_t, std::optional<Type>>> members;
 };
+
+inline std::string TypeToString(const Type& type) {
+    return std::visit(utils::overloaded {
+        [](const PrimitiveType& t) { return FromPrimitiveType(t.type); },
+        [](const PointerType& t) {
+            auto pointed = TypeToString(*t.to);
+            return fmt::format("{}*", pointed);
+        },
+        [](const StructuredType& t) {
+            return t.name;
+        }
+    }, type);
+}


### PR DESCRIPTION
The variable command now allows to read and modify variable - if proper debug info is present. The setting of variable only works for primitive types and the user can only enter integers. This is a subject for future PR.