### PR TITLE
Add dereference instruction to location.

### DIFF
--- a/t86/debugger/Source/ExpressionInterpreter.cpp
+++ b/t86/debugger/Source/ExpressionInterpreter.cpp
@@ -66,6 +66,20 @@ void ExpressionInterpreter::Interpret() {
                 auto loc = bp + ins.offset;
                 s.push(expr::Offset{loc});
             },
+            [&](const expr::Dereference& ins) {
+                auto v1 = s.top();
+                auto v = std::visit(utils::overloaded {
+                        [&](const expr::Register& reg) {
+                            auto idx = native.GetRegister(reg.name);
+                            return native.ReadMemory(idx, 1)[0];
+                        },
+                        [&](const expr::Offset& offset) {
+                            auto idx = native.ReadMemory(offset.value, 1)[0];
+                            return native.ReadMemory(idx, 1)[0];
+                        }
+                }, v1);
+                s.push(expr::Offset{v});
+            }
         }, ins);
     }
 }

--- a/t86/debugger/Source/LocExpr.h
+++ b/t86/debugger/Source/LocExpr.h
@@ -43,5 +43,9 @@ struct FrameBaseRegisterOffset {
     int64_t offset;
 };
 
-using LocExpr = std::variant<Push, Add, FrameBaseRegisterOffset>;
+struct Dereference {
+    uint64_t location;
+};
+
+using LocExpr = std::variant<Push, Add, FrameBaseRegisterOffset, Dereference>;
 }

--- a/t86/tests/debugger/expr_test.cpp
+++ b/t86/tests/debugger/expr_test.cpp
@@ -33,12 +33,25 @@ TEST(LocationExpr, RegResult) {
     std::vector<expr::LocExpr> exprs = {
         Push{Register{"R0"}}, 
     };
-    std::map<std::string, int64_t> regs = {
-        {"R0", 5},
-    };
     // Can't use make_unique with init lists :(
     std::unique_ptr<MockedProcess> p{new MockedProcess({}, {}, {{"BP", 20}})};
     Native n(std::move(p));
     auto res = ExpressionInterpreter::Interpret(exprs, n);
     ASSERT_EQ(std::get<Register>(res).name, "R0");
+}
+
+TEST(LocationExpr, Dereference) {
+    std::vector<expr::LocExpr> exprs = {
+        Push{Register{"R0"}}, 
+        Dereference{},
+    };
+    std::map<std::string, int64_t> regs = {
+        {"R0", 2},
+        {"BP", 20}
+    };
+    // Can't use make_unique with init lists :(
+    std::unique_ptr<MockedProcess> p{new MockedProcess({}, {1,2,3,4,5}, regs)};
+    Native n(std::move(p));
+    auto res = ExpressionInterpreter::Interpret(exprs, n);
+    ASSERT_EQ(std::get<Offset>(res).value, 3);
 }


### PR DESCRIPTION
Add new instruction which looks at the value at the top of the stack, interprets it as memory address and dereferences it. Can be value for pointers and references in the future.
Closes #98 