### PR TITLE
Add expression parser.

### DIFF
--- a/t86/dbg-cli/tests/sources/swap.t86
+++ b/t86/dbg-cli/tests/sources/swap.t86
@@ -74,12 +74,12 @@ DIE_function: {
         DIE_variable: {
             ATTR_name: x,
             ATTR_type: 1,
-            ATTR_location: ``,
+            ATTR_location: [],
         },
         DIE_variable: {
             ATTR_name: y,
             ATTR_type: 1,
-            ATTR_location: ``,
+            ATTR_location: [],
         },
         DIE_variable: {
             ATTR_name: tmp,

--- a/t86/debugger/Source/ExpressionInterpreter.cpp
+++ b/t86/debugger/Source/ExpressionInterpreter.cpp
@@ -13,13 +13,13 @@ expr::Location ExpressionInterpreter::Interpret(const std::vector<expr::LocExpr>
     ExpressionInterpreter vm(expr, native, std::move(frame_base_reg_name));
     vm.Interpret();
     if (vm.s.empty()) {
-        throw InterpretError("Empty stack at the end of calculation");
+        throw DebuggerError("Empty stack at the end of location expression evaluation.");
     }
     return vm.s.top();
 }
 
 expr::Location ExpressionInterpreter::AddOperands(const expr::Location& o1,
-                                                 const expr::Location& o2) const {
+                                                  const expr::Location& o2) const {
     return std::visit(utils::overloaded {
         [&](const expr::Offset& i1) {
             return std::visit(utils::overloaded {

--- a/t86/debugger/Source/ExpressionParser.cpp
+++ b/t86/debugger/Source/ExpressionParser.cpp
@@ -1,0 +1,116 @@
+#include "ExpressionParser.h"
+
+std::unique_ptr<Expression> ExpressionParser::expr() {
+    return equality(); 
+}
+
+std::unique_ptr<Expression> ExpressionParser::equality() {
+    std::unique_ptr<Expression> result = comparison();
+    while (curtok.kind == TokenKind::EQ) {
+        GetNext();
+        auto next = comparison();
+        NOT_IMPLEMENTED;
+    }
+    return result;
+}
+
+std::unique_ptr<Expression> ExpressionParser::comparison() {
+    std::unique_ptr<Expression> result = term();
+    while (curtok.kind == TokenKind::LESS || curtok.kind == TokenKind::GREATER) {
+        GetNext();
+        auto next = factor();
+        NOT_IMPLEMENTED;
+    }
+    return result;
+}
+
+std::unique_ptr<Expression> ExpressionParser::term() {
+    std::unique_ptr<Expression> result = factor();
+    while (curtok.kind == TokenKind::PLUS) {
+        GetNext();
+        auto next = factor();
+        result = std::make_unique<Plus>(std::move(result), std::move(next));
+    }
+    return result;
+}
+
+std::unique_ptr<Expression> ExpressionParser::factor() {
+    std::unique_ptr<Expression> result = unary();
+    while (curtok.kind == TokenKind::TIMES) {
+        GetNext();
+        auto next = unary();
+        NOT_IMPLEMENTED;
+    }
+    return result;
+}
+
+std::unique_ptr<Expression> ExpressionParser::unary() {
+    if (curtok.kind == TokenKind::TIMES) {
+        GetNext();
+        auto pstfx = postfix();
+        return std::make_unique<Dereference>(std::move(pstfx));
+    }
+    return postfix();
+}
+
+std::unique_ptr<Expression> ExpressionParser::postfix() {
+    auto p = primary();
+    while (curtok.kind == TokenKind::LBRACKET
+            || curtok.kind == TokenKind::DOT
+            || curtok.kind == TokenKind::ARROW) {
+        if (curtok.kind == TokenKind::LBRACKET) {
+            GetNext();
+            auto e = expr();
+            if (curtok.kind != TokenKind::RBRACKET) {
+                throw CreateError("Expected closing ']'");
+            }
+            GetNext();
+            p = std::make_unique<ArrayAccess>(std::move(p), std::move(e));
+        } else if (curtok.kind == TokenKind::DOT) {
+            if (GetNext() != TokenKind::ID) {
+                throw CreateError("Expected member name after '.'");
+            }
+            auto member = lex.getId();
+            GetNext();
+            p = std::make_unique<MemberAccess>(std::move(p), std::move(member));
+        } else if (curtok.kind == TokenKind::ARROW) {
+            if (GetNext() != TokenKind::ID) {
+                throw CreateError("Expected member name after '.'");
+            }
+            auto member = lex.getId();
+            GetNext();
+            p = std::make_unique<MemberDereferenceAccess>(std::move(p),
+                                                          std::move(member));
+        } else {
+            break;
+        }
+    }
+    return p;
+}
+
+std::unique_ptr<Expression> ExpressionParser::primary() {
+    if (curtok.kind == TokenKind::NUM) {
+        auto num = lex.getNumber();
+        GetNext();
+        return std::make_unique<Integer>(num);
+    } else if (curtok.kind == TokenKind::FLOAT) {
+        auto num = lex.getFloat();
+        GetNext();
+        return std::make_unique<Float>(num);
+    } else if (curtok.kind == TokenKind::ID) {
+        auto id = lex.getId();
+        GetNext();
+        return std::make_unique<Identifier>(std::move(id));
+    } else if (curtok.kind == TokenKind::LPAREN) {
+        GetNext();
+        auto e = expr();
+        if (curtok.kind != TokenKind::RPAREN) {
+            throw CreateError("Expected closing parentheses");
+        }
+        GetNext();
+        return e;
+    } else {
+        throw CreateError("Expected either identifier, int or float");
+    }
+}
+

--- a/t86/debugger/Source/ExpressionParser.h
+++ b/t86/debugger/Source/ExpressionParser.h
@@ -1,0 +1,49 @@
+#pragma once
+#include "common/parsing.h"
+#include "debugger/Source/Expression.h"
+
+/** The grammar:
+ * Lexical syntax:
+ *  Number = Integer and floating point numbers.
+ *  ID = Identifier containing letter, numbers and underscores.
+ *       Can't begin with a number.
+ *                   
+ * Context-free syntax:
+ *  expr = equality
+ *  equality = comparison {("==" | "!=") comparison}
+ *  comparison = term {("<" | "<=" | ">=" | ">") term}
+ *  term = factor {("+" | "-") factor}
+ *  factor = unary {("*" | "/") unary}
+ *  unary = ["*"] postfix
+ *  postfix = primary ([ "[" expr "]" ] | "->" ID | "." ID)
+ *  primary = Number | ID | "(" expr ")"
+ */
+
+class ExpressionParser {
+public:
+    ExpressionParser(std::istream& is): lex(is) { GetNext(); }
+    std::unique_ptr<Expression> ParseExpression() {
+        return expr();
+    }
+private:
+    template<typename ...Args>
+    ParserError CreateError(fmt::format_string<Args...> format, Args&& ...args) const {
+        return ParserError(fmt::format("Error:{}:{}:{}", curtok.row,
+                    curtok.col, fmt::format(format,
+                        std::forward<Args>(args)...)));
+    }
+
+    std::unique_ptr<Expression> expr();
+    std::unique_ptr<Expression> equality();
+    std::unique_ptr<Expression> comparison();
+    std::unique_ptr<Expression> term();
+    std::unique_ptr<Expression> factor();
+    std::unique_ptr<Expression> unary();
+    std::unique_ptr<Expression> postfix();
+    std::unique_ptr<Expression> primary();
+    TokenKind GetNext() {
+        return (curtok = lex.getNext()).kind;
+    }
+    Lexer lex;
+    Token curtok;
+};

--- a/t86/debugger/Source/Source.cpp
+++ b/t86/debugger/Source/Source.cpp
@@ -309,6 +309,15 @@ std::map<std::string, const DIE*> Source::GetActiveVariables(uint64_t address) c
     return result;
 }
 
+TypedValue Source::EvaluateExpression(Native& native, std::string expression) {
+    std::istringstream iss(std::move(expression));
+    ExpressionParser parser(iss);
+    auto e = parser.ParseExpression();
+    ExpressionEvaluator eval(native, *this);
+    e->Accept(eval);
+    return eval.YieldResult();
+}
+
 std::set<std::string> Source::GetScopedVariables(uint64_t address) const {
     std::set<std::string> result;
     auto vars = GetActiveVariables(address);

--- a/t86/debugger/Source/Source.h
+++ b/t86/debugger/Source/Source.h
@@ -1,5 +1,7 @@
 #pragma once
 #include <algorithm>
+#include "debugger/Source/Expression.h"
+#include "debugger/Source/ExpressionParser.h"
 #include "debugger/Source/LineMapping.h"
 #include "debugger/Source/SourceFile.h"
 #include "debugger/Source/Type.h"
@@ -95,6 +97,8 @@ public:
 
     /// Return names of variables that are currently in scope.
     std::set<std::string> GetScopedVariables(uint64_t address) const;
+
+    TypedValue EvaluateExpression(Native& native, std::string expression);
 
     /// Returns lines from the source file. This function does
     /// not throw if out of bounds, instead it stops.

--- a/t86/tests/debugger/expr_test.cpp
+++ b/t86/tests/debugger/expr_test.cpp
@@ -43,7 +43,7 @@ TEST(LocationExpr, RegResult) {
 TEST(LocationExpr, Dereference) {
     std::vector<expr::LocExpr> exprs = {
         Push{Register{"R0"}}, 
-        Dereference{},
+        expr::Dereference{},
     };
     std::map<std::string, int64_t> regs = {
         {"R0", 2},

--- a/t86/tests/t86/parser_test.cpp
+++ b/t86/tests/t86/parser_test.cpp
@@ -132,7 +132,7 @@ TEST(TokenizerTest, Floats2) {
 }
 
 TEST(TokenizerTest, Ignore) {
-    std::istringstream iss("A B ( % @ A %");
+    std::istringstream iss("A B @ % @ A %");
     Lexer l(iss);
     ASSERT_EQ(l.getNext(), _T(TokenKind::ID, 0, 0));
     ASSERT_EQ(l.getNext(), _T(TokenKind::ID, 0, 2));


### PR DESCRIPTION
Add expression parser for the CLI to use. The expression supports only basic TinyC expressions, like addition, dereference, member access and array access. With the baseline, extension is trivial. But we will need to evaluate if it is worth it.