### PR TITLE
Rework lexer and parsers to properly accepts '-'.

### DIFF
--- a/t86/common/parsing.h
+++ b/t86/common/parsing.h
@@ -32,6 +32,7 @@ enum class TokenKind {
     END,
     SEMICOLON,
     PLUS,
+    MINUS,
     TIMES,
     LESS,
     GREATER,
@@ -91,8 +92,7 @@ public:
         ignore = on;
     }
 
-    TokenKind ParseNumber(bool negative) {
-        int neg = negative ? -1 : 1;
+    TokenKind ParseNumber() {
         bool is_float = false;
         std::string num{lookahead};
         while (true) {
@@ -106,10 +106,10 @@ public:
             num += lookahead;
         }
         if (is_float) {
-            float_number = neg * std::stod(num);
+            float_number = std::stod(num);
             return TokenKind::FLOAT;
         } else {
-            number = neg * std::stoi(num);
+            number = std::stoi(num);
             return TokenKind::NUM;
         }
     }
@@ -182,6 +182,13 @@ public:
         } else if (lookahead == '+') {
             GetChar();
            return MakeToken(TokenKind::PLUS);
+        } else if (lookahead == '-') {
+            GetChar();
+            if (lookahead == '>') {
+                GetChar();
+                return MakeToken(TokenKind::ARROW);
+            }
+           return MakeToken(TokenKind::MINUS);
         } else if (lookahead == '>') {
             GetChar();
            return MakeToken(TokenKind::GREATER);
@@ -203,24 +210,8 @@ public:
         } else if (lookahead == '"') {
             ParseString();
             return MakeToken(TokenKind::STRING);
-        } else if (isdigit(lookahead) || lookahead == '-') {
-            bool negative = false;
-            if (lookahead == '-') {
-                negative = lookahead == '-';
-                GetChar();
-            }
-            if (isdigit(lookahead)) {
-                // Can be either int or float
-                return MakeToken(ParseNumber(negative));
-            } else {
-                if (lookahead == '>') {
-                    GetChar();
-                    return MakeToken(TokenKind::ARROW);
-                } else {
-                    throw ParserError(fmt::format("{}:{}:Expected either number or '>'",
-                                                  row, col));
-                }
-            }
+        } else if (isdigit(lookahead)) {
+            return MakeToken(ParseNumber());
         } else if (isalpha(lookahead) || lookahead == '_') { // identifier
             ParseIdentifier();
             return MakeToken(TokenKind::ID);

--- a/t86/dbg-cli/tests/sources/linked_list.t86
+++ b/t86/dbg-cli/tests/sources/linked_list.t86
@@ -5,32 +5,32 @@
 2       PUSH    BP
 3       MOV     BP, SP
 4       SUB     SP, 8
-5       MOV     [BP + -4], 5
-6       LEA     R1, [BP + -6]
-7       MOV     [BP + -3], R1
-8       MOV     R1, [BP + -3]
+5       MOV     [BP - 4], 5
+6       LEA     R1, [BP - 6]
+7       MOV     [BP - 3], R1
+8       MOV     R1, [BP - 3]
 90      MOV     [R1], 10
-10      MOV     R1, [BP + -3]
-11      LEA     R2, [BP + -8]
+10      MOV     R1, [BP - 3]
+11      LEA     R2, [BP - 8]
 12      MOV     [R1 + 1], R2
-13      MOV     R1, [BP + -3]
+13      MOV     R1, [BP - 3]
 14      MOV     R1, [R1 + 1]
 15      MOV     [R1], 15
-16      MOV     R1, [BP + -3]
+16      MOV     R1, [BP - 3]
 17      MOV     R1, [R1 + 1]
 18      MOV     [R1 + 1], 0
-19      LEA     R1, [BP + -4]
-20      MOV     [BP + -1], R1
+19      LEA     R1, [BP - 4]
+20      MOV     [BP - 1], R1
 21      JMP     28
 # .L3:
-22      MOV     R1, [BP + -1]
+22      MOV     R1, [BP - 1]
 23      MOV     R1, [R1]
 24      PUTNUM  R1
-25      MOV     R1, [BP + -1]
+25      MOV     R1, [BP - 1]
 26      MOV     R1, [R1 + 1]
-27      MOV     [BP + -1], R1
+27      MOV     [BP - 1], R1
 # .L2:
-28      MOV     R0, [BP + -1]
+28      MOV     R0, [BP - 1]
 29      CMP     R0, 0
 30      JNE     22
 31      MOV     R0, 0

--- a/t86/dbg-cli/tests/sources/llvm.ir
+++ b/t86/dbg-cli/tests/sources/llvm.ir
@@ -5,13 +5,13 @@
 # main:
 2       PUSH    BP
 3       MOV     BP, SP
-4       MOV     [BP + -1], 0
-5       MOV     [BP + -2], 5
+4       MOV     [BP - 1], 0
+5       MOV     [BP - 2], 5
 6       LEA     R0, [BP + -2]
-7       MOV     [BP + -4], R0
+7       MOV     [BP - 4], R0
 8       MOV     R0, [BP + -4]
 9       MOV     [R0], 10
-10      MOV     R0, [BP + -4]
+10      MOV     R0, [BP - 4]
 11      MOV     R1, [R0]
 12      ADD     R1, [BP + -2]
 13      POP     BP

--- a/t86/debugger/Source/Parser.h
+++ b/t86/debugger/Source/Parser.h
@@ -31,6 +31,7 @@ private:
     DIE ParseDIE(std::string name);
     ATTR_members StructuredMembers();
     DIE::TAG ParseDIETag(std::string_view v) const;
+    expr::Offset ParseOffset();
     DIE_ATTR ParseATTR(std::string_view v);
     std::vector<expr::LocExpr> ParseExprLoc();
     expr::Location ParseOperand();

--- a/t86/t86-parser/parser.h
+++ b/t86/t86-parser/parser.h
@@ -67,6 +67,15 @@ public:
 
     std::unique_ptr<tiny::t86::Instruction> Instruction();
 
+    /// Returns true if the current token represents a number.
+    /// In a normal world where expression are arbitrary, the 
+    /// parse would be covered by an unary operator expression.
+    /// The T86 however places strict conditions on the expressions,
+    /// and so we have to check the lookahead like this.
+    bool IsNumber(Token tk) {
+        return tk.kind == TokenKind::NUM || tk.kind == TokenKind::MINUS;
+    }
+
     void Text();
 
     void Data();

--- a/t86/tests/debugger/native_test.cpp
+++ b/t86/tests/debugger/native_test.cpp
@@ -210,25 +210,25 @@ TEST_F(NativeTest, MultipleBreakpointHits) {
 0 NOP
 1 MOV BP, SP
 2 SUB SP, 1
-3 MOV [BP + -1], 0
+3 MOV [BP - 1], 0
 4 JMP 14
 
 # Check if iter variable is odd and print if so
-5 MOV R0, [BP + -1]
+5 MOV R0, [BP - 1]
 6 AND R0, 1
 7 CMP R0, 1
 8 JNE 11
 
-9 MOV R0, [BP + -1]
+9 MOV R0, [BP - 1]
 10 ADD R1, R0
 
 # Increment iteration variable
-11 MOV R0, [BP + -1]
+11 MOV R0, [BP - 1]
 12 ADD R0, 1
-13 MOV [BP + -1], R0
+13 MOV [BP - 1], R0
 
 # Condition check
-14 MOV R0, [BP + -1]
+14 MOV R0, [BP - 1]
 15 CMP R0, 9
 16 JLE 5
 
@@ -268,20 +268,20 @@ TEST_F(NativeTest, EnableDisableBreakpoints) {
 0 NOP
 1 MOV BP, SP
 2 SUB SP, 1
-3 MOV [BP + -1], 0
+3 MOV [BP - 1], 0
 4 JMP 14
 
 # Check if iter variable is odd and print if so
-5 MOV R0, [BP + -1]
+5 MOV R0, [BP - 1]
 6 AND R0, 1
 7 CMP R0, 1
 8 JNE 11
 
-9 MOV R0, [BP + -1]
+9 MOV R0, [BP - 1]
 10 ADD R1, R0
 
 # Increment iteration variable
-11 MOV R0, [BP + -1]
+11 MOV R0, [BP - 1]
 12 ADD R0, 1
 13 MOV [BP + -1], R0
 

--- a/t86/tests/t86/parser_test.cpp
+++ b/t86/tests/t86/parser_test.cpp
@@ -56,8 +56,9 @@ TEST(TokenizerTest, Minus) {
     Lexer l(iss);
     ASSERT_EQ(l.getNext(), _T(TokenKind::ID, 0, 0));
     ASSERT_EQ(l.getNext(), _T(TokenKind::LBRACKET, 0, 4));
-    ASSERT_EQ(l.getNext(), _T(TokenKind::NUM, 0, 5));
-    ASSERT_EQ(l.getNumber(), -1);
+    ASSERT_EQ(l.getNext(), _T(TokenKind::MINUS, 0, 5));
+    ASSERT_EQ(l.getNext(), _T(TokenKind::NUM, 0, 6));
+    ASSERT_EQ(l.getNumber(), 1);
     ASSERT_EQ(l.getNext(), _T(TokenKind::RBRACKET, 0, 7));
     ASSERT_EQ(l.getNext(), _T(TokenKind::COMMA, 0, 8));
     ASSERT_EQ(l.getNext(), _T(TokenKind::ID, 0, 10));


### PR DESCRIPTION
The T86 assembly allowed only `[R0 + -1]`, and not `[R0 - 1]`, which was stupid to write. This patch remedies that. It had to be changed in many places of the code and unfortunately, somewhere it is kind of hardcoded. This is due to T86 not allowing arbitrary expressions but it has a rather strict set of allowed ones. This means that it can't just simply be a `prefix()` rule of the grammar.

The change has been propagated to other places, like debug information.