### PR TITLE
Add assignment operator to expressions.

### DIFF
--- a/t86/common/parsing.cpp
+++ b/t86/common/parsing.cpp
@@ -99,7 +99,7 @@ Token Lexer::getNext() {
         GetChar();
         if (lookahead == '=') {
             GetChar();
-            MakeToken(TokenKind::EQ);
+            return MakeToken(TokenKind::EQ);
         }
         return MakeToken(TokenKind::ASSIGN);
     } else if (lookahead == '%') {

--- a/t86/dbg-cli/tests/no-source-info1.in
+++ b/t86/dbg-cli/tests/no-source-info1.in
@@ -3,7 +3,6 @@ b s 5
 b is 5
 is
 b s main
-var set a 1
 frame
 c
 b irem 5

--- a/t86/dbg-cli/tests/no-source-info1.ref
+++ b/t86/dbg-cli/tests/no-source-info1.ref
@@ -6,7 +6,6 @@ Breakpoint set on address 5: 'MOV R0, [BP + -1]'
       2:  MOV R0, [BP + -1]
       3:  MOV R1, [R0]
 Error: Expected line or function name, 'main' is neither.
-Error: Variable 'a' is not in scope or missing debug info
 HProcess stopped, reason: Software breakpoint hit at address 5
       3:  MOV R1, [R0]
       4:  PUTCHAR R1

--- a/t86/debugger/Source/ExpressionParser.cpp
+++ b/t86/debugger/Source/ExpressionParser.cpp
@@ -19,6 +19,7 @@ static const std::map<TokenKind, BinaryOperator::Op> operators = {
     {TokenKind::XOR, BinaryOperator::Op::IXor},
     {TokenKind::LSHIFT, BinaryOperator::Op::LShift},
     {TokenKind::RSHIFT, BinaryOperator::Op::RShift},
+    {TokenKind::ASSIGN, BinaryOperator::Op::Assign},
 };
 
 static const std::map<TokenKind, UnaryOperator::Op> unary_operators = {
@@ -28,7 +29,20 @@ static const std::map<TokenKind, UnaryOperator::Op> unary_operators = {
 };
 
 std::unique_ptr<Expression> ExpressionParser::expr() {
-    return equality(); 
+    return assign(); 
+}
+
+std::unique_ptr<Expression> ExpressionParser::assign() {
+    std::unique_ptr<Expression> result = equality();
+    while (curtok.kind == TokenKind::ASSIGN) {
+        auto kind = curtok.kind;
+        GetNext();
+        auto next = equality();
+        result = std::make_unique<BinaryOperator>(std::move(result),
+                                                  operators.at(kind),
+                                                  std::move(next));
+    }
+    return result;
 }
 
 std::unique_ptr<Expression> ExpressionParser::equality() {

--- a/t86/debugger/Source/ExpressionParser.h
+++ b/t86/debugger/Source/ExpressionParser.h
@@ -11,7 +11,8 @@
 ///       Can't begin with a number.
 ///                  
 /// Context-free syntax:
-///  expr = equality
+///  expr = assign
+///  assign = equality {"=" equality}
 ///  equality = logical {("==" | "!=") logical}
 ///  logical = comparison {("&&" | "||") comparison}
 ///  comparison = term {("<" | "<=" | ">=" | ">") term}
@@ -37,6 +38,7 @@ private:
     }
 
     std::unique_ptr<Expression> expr();
+    std::unique_ptr<Expression> assign();
     std::unique_ptr<Expression> equality();
     std::unique_ptr<Expression> logical();
     std::unique_ptr<Expression> comparison();

--- a/t86/tests/debugger/utils.h
+++ b/t86/tests/debugger/utils.h
@@ -269,6 +269,11 @@ DIE_function: {
             ATTR_location: `BASE_REG_OFFSET -4`,
         },
         DIE_variable: {
+            ATTR_name: l2,
+            ATTR_type: 1,
+            ATTR_location: `BASE_REG_OFFSET -6`,
+        },
+        DIE_variable: {
             ATTR_name: it,
             ATTR_type: 2,
             ATTR_location: `BASE_REG_OFFSET -1`,


### PR DESCRIPTION
Add a possibility to modify the values with assignment operator. It behaves like a C assignment operator, able to be used inside expressions. The TypedValues have another field, representing optional location. This is used to track if the value is RValue and the location it resides. It was implemented together with a parser and is functional for all existing types.

Also remove the old `var set` command, which is obsolete now.