### PR TITLE
Fix step out not behaving properly.

### DIFF
--- a/t86/debugger/Native.cpp
+++ b/t86/debugger/Native.cpp
@@ -163,14 +163,15 @@ DebugEvent Native::PerformStepOut() {
             rets, [&text](auto &&ins) { return text.starts_with(ins); });
         DebugEvent e;
         if (first) {
-            e = PerformSingleStep();
+            e = PerformStepOver();
         } else {
-            e = DoRawSingleStep();
+            e = PerformStepOver(false);
         }
         if (is_return != rets.end()
             || !std::holds_alternative<Singlestep>(e)) {
             return e;
         }
+        first = false;
     }
 }
 


### PR DESCRIPTION
Step out had two issues. It just straight up didn't respect breakpoints and it stepped over them. This was because a variable hasn't been properly set. The second one was if the function called another, it had a ret instruction and the step out would finish there instead of at the ret of the current function. This was solved by using step-over instead of normal single step for the step out.

Closes #152.