### PR TITLE
Fix step over with recursive functions.

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -153,6 +153,10 @@ The native part offers three ways of stepping.
 Do note that if any other event happens while stepping (like breakpoint hit or HALT),
 then the program is stopped at that point.
 
+For step out and over to work correctly in recursive functions it is needed to
+properly backup base pointer (`PUSH BP; MOV BP, SP`). It uses it as a heuristic
+to know that the expected frame has finished.
+
 The source level debugging offers:
 - `step` = Continue execution until another source line is encountered.
 - `next` = Same as step, but step over `CALL` instructions.


### PR DESCRIPTION
Step over puts a breakpoint after the call. However, when the call is recursive, it hits the breakpoint also. We now check if the base pointer is the same as in the function where the breakpoint was hit. This change expects that the program will behave sanely. It has been also added to documentation.