### PR TITLE
Allow spaces in GETCHAR instruction

### DIFF
--- a/src/t86/instruction.h
+++ b/src/t86/instruction.h
@@ -1111,7 +1111,9 @@ class INS_NAME : public ConditionalJumpInstruction {          \
 
     class GETCHAR : public Instruction {
     public:
-        GETCHAR(Register reg, std::istream& is = std::cin) : reg_(reg), is_(is) {}
+        GETCHAR(Register reg, std::istream& is = std::cin) : reg_(reg), is_(is) {
+            is_ >> std::noskipws;
+        }
 
         Type type() const override { return Type::GETCHAR; }
 


### PR DESCRIPTION
I don't see why the GETCHAR instruction should ignore whitespaces on stdin. Causes problems when running programs which do interesting stuff with stdin.